### PR TITLE
feat: add services and API calls with zustand

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,11 @@
+export const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000/api';
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`, init);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export { fetchJson };

--- a/src/services/bookingsService.ts
+++ b/src/services/bookingsService.ts
@@ -1,0 +1,14 @@
+import type { Ticket } from '../types/cinema';
+import { fetchJson } from './api';
+
+export async function getBookings(): Promise<Ticket[]> {
+  return fetchJson<Ticket[]>('/bookings/');
+}
+
+export async function createBooking(ticket: Ticket): Promise<Ticket> {
+  return fetchJson<Ticket>('/bookings/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(ticket),
+  });
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,4 @@
+export * from './api';
+export * from './moviesService';
+export * from './sessionsService';
+export * from './bookingsService';

--- a/src/services/moviesService.ts
+++ b/src/services/moviesService.ts
@@ -1,0 +1,10 @@
+import type { Movie } from '../types/cinema';
+import { fetchJson } from './api';
+
+export async function getMovies(): Promise<Movie[]> {
+  return fetchJson<Movie[]>('/movies/');
+}
+
+export async function getMovie(id: string): Promise<Movie> {
+  return fetchJson<Movie>(`/movies/${id}/`);
+}

--- a/src/services/sessionsService.ts
+++ b/src/services/sessionsService.ts
@@ -1,0 +1,11 @@
+import type { Session } from '../types/cinema';
+import { fetchJson } from './api';
+
+export async function getSessions(movieId?: string): Promise<Session[]> {
+  const path = movieId ? `/movies/${movieId}/sessions/` : '/sessions/';
+  return fetchJson<Session[]>(path);
+}
+
+export async function getSession(id: string): Promise<Session> {
+  return fetchJson<Session>(`/sessions/${id}/`);
+}

--- a/src/stores/bookingsStore.ts
+++ b/src/stores/bookingsStore.ts
@@ -1,17 +1,28 @@
 import { create } from 'zustand';
 import type { Ticket } from '../types/cinema';
+import {
+  getBookings,
+  createBooking as apiCreateBooking,
+} from '../services/bookingsService';
 
 interface BookingsState {
   bookings: Ticket[];
-  addBooking: (ticket: Ticket) => void;
+  fetchBookings: () => Promise<void>;
+  createBooking: (ticket: Ticket) => Promise<void>;
   removeBooking: (id: string) => void;
   clearBookings: () => void;
 }
 
 export const useBookingsStore = create<BookingsState>((set) => ({
   bookings: [],
-  addBooking: (ticket) =>
-    set((state) => ({ bookings: [...state.bookings, ticket] })),
+  fetchBookings: async () => {
+    const bookings = await getBookings();
+    set({ bookings });
+  },
+  createBooking: async (ticket) => {
+    const saved = await apiCreateBooking(ticket);
+    set((state) => ({ bookings: [...state.bookings, saved] }));
+  },
   removeBooking: (id) =>
     set((state) => ({
       bookings: state.bookings.filter((b) => b.id !== id),

--- a/src/stores/moviesStore.ts
+++ b/src/stores/moviesStore.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
 import type { Movie } from '../types/cinema';
+import { getMovies } from '../services/moviesService';
 
 interface MoviesState {
   movies: Movie[];
   selectedMovie?: Movie;
+  fetchMovies: () => Promise<void>;
   setMovies: (movies: Movie[]) => void;
   addMovie: (movie: Movie) => void;
   selectMovie: (id: string) => void;
@@ -13,6 +15,10 @@ interface MoviesState {
 export const useMoviesStore = create<MoviesState>((set) => ({
   movies: [],
   selectedMovie: undefined,
+  fetchMovies: async () => {
+    const movies = await getMovies();
+    set({ movies });
+  },
   setMovies: (movies) => set({ movies }),
   addMovie: (movie) =>
     set((state) => ({

--- a/src/stores/sessionsStore.ts
+++ b/src/stores/sessionsStore.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
 import type { Session } from '../types/cinema';
+import { getSessions } from '../services/sessionsService';
 
 interface SessionsState {
   sessions: Session[];
   selectedSession?: Session;
+  fetchSessions: (movieId?: string) => Promise<void>;
   setSessions: (sessions: Session[]) => void;
   addSession: (session: Session) => void;
   selectSession: (id: string) => void;
@@ -13,6 +15,10 @@ interface SessionsState {
 export const useSessionsStore = create<SessionsState>((set) => ({
   sessions: [],
   selectedSession: undefined,
+  fetchSessions: async (movieId) => {
+    const sessions = await getSessions(movieId);
+    set({ sessions });
+  },
   setSessions: (sessions) => set({ sessions }),
   addSession: (session) =>
     set((state) => ({ sessions: [...state.sessions, session] })),


### PR DESCRIPTION
## Summary
- add API helper and services for movies, sessions, and bookings
- integrate Zustand stores with async fetch actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Could not resolve "./App.css")

------
https://chatgpt.com/codex/tasks/task_e_68989cc0d658832db0c7db21eae035fb